### PR TITLE
[Vagrantfile] Synced folder modification

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "../vagrant-frontend-mobile-box/ng-box/projects", "/vagrant_data", create: true
+  config.vm.synced_folder "../vagrant-frontend-mobile-box/projects", "/vagrant_data", create: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "/home/willmendesneto/projects/ng-box/projects", "/vagrant_data"
+  config.vm.synced_folder ENV['HOME'] + "/ng-box/projects", "/vagrant_data", create: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  # accessing "localhost:8180" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 80, host: 8180
   config.vm.network "forwarded_port", guest: 8100, host: 8100
   # node server port
   config.vm.network "forwarded_port", guest: 9000, host: 9000
@@ -52,7 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "/home/willmendesneto/projects/ng-box/projects", "/vagrant_data"
+  config.vm.synced_folder ENV['HOME'] + "/ng-box/projects", "/vagrant_data", create: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8180" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 80, host: 8180
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.network "forwarded_port", guest: 8100, host: 8100
   # node server port
   config.vm.network "forwarded_port", guest: 9000, host: 9000
@@ -52,7 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ENV['HOME'] + "/ng-box/projects", "/vagrant_data", create: true
+  config.vm.synced_folder "/home/willmendesneto/projects/ng-box/projects", "/vagrant_data"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ENV['HOME'] + "/ng-box/projects", "/vagrant_data", create: true
+  config.vm.synced_folder "../vagrant-frontend-mobile-box/ng-box/projects", "/vagrant_data", create: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
-synced_folder is pointing to $HOME/ng-box/projects and will create the
dir, if it doesn't exist.
-Server port changed from 8080 to 8180 because 8080 is Jenkins default
port.
